### PR TITLE
Create a function that imports or stubs a module, at the module level

### DIFF
--- a/surrogate.py
+++ b/surrogate.py
@@ -1,5 +1,6 @@
 import sys
 from functools import wraps
+import importlib
 
 __all__ = ('surrogate', )
 
@@ -157,3 +158,34 @@ class surrogate(object):
                 del self.base_module.__all__
             if hasattr(self.base_module, self.elements[0]):
                 delattr(self.base_module, self.elements[0])
+
+
+def importorinject(modulename):
+    """
+    Returns a module if modulename exists or stubs it and returns the stub.
+
+    This will import the modulename for the whole scope. There is no need to write @surrogate("modulename") before
+    each test case. The intention is to provide something similar to  pytest.importorskip function:
+    https://docs.pytest.org/en/6.2.x/reference.html#pytest-importorskip
+
+    Usage:
+        Instead of:
+
+            import some_module
+
+        that could potentially fail if there is no some_module, write this at test module level
+
+            some_module = importorinject("some_module")
+
+        Inside the test functions, some_module module/object will be available for usage, mocking, etc.
+
+    Args:
+        modulename: (str) The path/name of the module
+
+    Returns:
+
+    """
+    surrogate_obj = surrogate(modulename)
+    surrogate_obj.prepare()
+    module = importlib.import_module(modulename)
+    return module

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,5 @@
 import unittest
-from surrogate import surrogate
+from surrogate import surrogate, importorinject
 
 def imports():
     import my
@@ -21,7 +21,7 @@ class TestSurrogateModuleStubs(unittest.TestCase):
 
         try:
             stubbed()
-        except Exception, e:
+        except Exception as e:
             raise Exception('Modules are not stubbed correctly: %r' % e)
 
         with self.assertRaises(ImportError) as e:
@@ -32,6 +32,16 @@ class TestSurrogateModuleStubs(unittest.TestCase):
             with surrogate('my.module.one'):
                 with surrogate('my.module.two'):
                     imports()
+
+
+    def test_import_for_whole_module(self):
+        some_module = importorinject("some_module")
+        datetime = importorinject("datetime")
+
+        assert some_module is not None
+        assert datetime is not None
+        result = datetime.date(2021, 4, 20)
+        assert result is not None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi! I use this library on embedded/hardware testing scenarios where various hardware libs are not available on regular computers.

I created something similar to https://docs.pytest.org/en/6.2.x/reference.html#pytest-importorskip but instead of skipping the whole test suite, just create a surrogate.

It is a syntax sugaring, getting rid of all the @surrogate before each test case.

Hope it helps!